### PR TITLE
Do not add deleted files to commit_paths.

### DIFF
--- a/svn2svn/run/svnreplay.py
+++ b/svn2svn/run/svnreplay.py
@@ -645,7 +645,8 @@ def process_svn_log_entry(log_entry, ancestors, commit_paths, prefix = ""):
         # Try to be efficient and keep track of an explicit list of paths in the
         # working copy that changed. If we commit from the root of the working copy,
         # then SVN needs to crawl the entire working copy looking for pending changes.
-        commit_paths.append(path_offset)
+        if action != 'D':
+            commit_paths.append(path_offset)
 
         # Special-handling for replace's
         if action == 'R':


### PR DESCRIPTION
svnreplay fails on "D" actions because it adds deleted files to the list of files to be committed, but by the time of commit they are already deleted from working directory.  This PR fixes the symptom, but I am not sure it cures the problem.
