### PR TITLE
Correct symbolic links handling

### DIFF
--- a/svn2svn/run/common.py
+++ b/svn2svn/run/common.py
@@ -11,7 +11,7 @@ def in_svn(p, require_in_repo=False, prefix=""):
     With SVN 1.7 and beyond, WC-NG means only a single top-level ".svn" at the root of the working-copy.
     Use "svn status" to check the status of the file/folder.
     """
-    entries = svnclient.status(p, non_recursive=True)
+    entries = svnclient.status(p, non_recursive=True, resolve_symlink=False)
     if not entries:
         return False
     d = entries[0]

--- a/svn2svn/run/svnreplay.py
+++ b/svn2svn/run/svnreplay.py
@@ -354,9 +354,9 @@ def full_svn_revert():
         for line in output_lines:
             if line[0] == "?":
                 path = line[4:].strip(" ")
-                if os.path.isfile(path):
+                if os.path.islink(path) or os.path.isfile(path):
                     os.remove(path)
-                if os.path.isdir(path):
+                elif os.path.isdir(path):
                     shell.rmtree(path)
 
 def gen_tracking_revprops(source_rev):


### PR DESCRIPTION
Fix for #20

Use parent directory for fetching real symlink status, because `svn status` follow links when used on them directly.